### PR TITLE
Change setup-dotnet to use @v1 again

### DIFF
--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Setup .NET Core
-      uses: actions/setup-dotnet@v1.6.0
+      uses: actions/setup-dotnet@v1
       with:
         dotnet-version: 3.1.x
     - name: Install dependencies


### PR DESCRIPTION
Reverts back to using the latest version of setup-dotnet. There was a problem with v1.7.0 that required us to go back to v1.6.0.

Closes #153 