### PR TITLE
196 Fix lag when starting after the first 3 notes

### DIFF
--- a/S2VX.Game/Play/PlayScreen.cs
+++ b/S2VX.Game/Play/PlayScreen.cs
@@ -69,7 +69,7 @@ namespace S2VX.Game.Play {
                 var settings = Story.EditorSettings;
                 var trackTime = settings.TrackTime;
                 track.Seek(trackTime);
-                Story.Notes.RemoveNotesUpTo(trackTime);
+                Story.RemoveNotesUpTo(trackTime);
             }
 
             Clock = new FramedClock(track);

--- a/S2VX.Game/Story/Note/Approach.cs
+++ b/S2VX.Game/Story/Note/Approach.cs
@@ -15,10 +15,10 @@ namespace S2VX.Game.Story.Note {
 
         private RelativeBox[] Lines { get; set; } = new RelativeBox[4]
         {
-            new RelativeBox(), // up	
-            new RelativeBox(), // down	
-            new RelativeBox(), // right	
-            new RelativeBox() // left	
+            new RelativeBox(), // up
+            new RelativeBox(), // down
+            new RelativeBox(), // right
+            new RelativeBox()  // left
         };
 
         [BackgroundDependencyLoader]
@@ -39,7 +39,7 @@ namespace S2VX.Game.Story.Note {
 
             if (time >= endFadeOut) {
                 Alpha = 0;
-                // Return early to save some calculations	
+                // Return early to save some calculations
                 return;
             }
 
@@ -59,7 +59,7 @@ namespace S2VX.Game.Story.Note {
             var rotationX = S2VXUtils.Rotate(new Vector2(distance, 0), rotation);
             var rotationY = S2VXUtils.Rotate(new Vector2(0, distance), rotation);
 
-            // Add extra thickness so corners overlap	
+            // Add extra thickness so corners overlap
             var overlap = distance * 2 + thickness;
 
             Lines[0].Position = offset + rotationY;

--- a/S2VX.Game/Story/Note/GameNote.cs
+++ b/S2VX.Game/Story/Note/GameNote.cs
@@ -102,6 +102,7 @@ namespace S2VX.Game.Story.Note {
             // Removes if this note has been flagged for removal by Delete(). Removal has to be delayed for earliestNote check to work.  
             if (ShouldBeRemoved) {
                 Story.RemoveNote(this);
+                return;
             }
 
             base.Update();

--- a/S2VX.Game/Story/Note/Notes.cs
+++ b/S2VX.Game/Story/Note/Notes.cs
@@ -3,10 +3,10 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osuTK.Graphics;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace S2VX.Game.Story.Note {
     public class Notes : CompositeDrawable {
+
         public List<S2VXNote> Children { get; private set; } = new List<S2VXNote>();
         public void SetChildren(List<S2VXNote> notes) {
             Children = notes;
@@ -35,23 +35,6 @@ namespace S2VX.Game.Story.Note {
         public void RemoveNote(S2VXNote note) {
             Children.Remove(note);
             RemoveInternal(note);
-        }
-
-        // Before starting the Story in the PlayScreen, we want to explicitly
-        // remove GameNotes up to some certain track time. This is so that we
-        // won't hear Miss hitsounds and prematurely calculate score.
-        public void RemoveNotesUpTo(double trackTime) {
-            int validIndex;
-            for (validIndex = 0; validIndex < Children.Count; ++validIndex) {
-                if (Children[validIndex].EndTime < trackTime) {
-                    break;
-                }
-            }
-
-            var newNotes = Children.Take(validIndex).ToList();
-            Children = newNotes;
-            ClearInternal(false);
-            InternalChildren = Children;
         }
 
         [BackgroundDependencyLoader]

--- a/S2VX.Game/Story/S2VXStory.cs
+++ b/S2VX.Game/Story/S2VXStory.cs
@@ -85,6 +85,18 @@ namespace S2VX.Game.Story {
             Approaches.RemoveApproach(note);
         }
 
+        // Before starting the Story in the PlayScreen, we want to explicitly
+        // remove GameNotes up to some certain track time. This is so that we
+        // won't hear Miss hitsounds and prematurely calculate score.
+        public void RemoveNotesUpTo(double trackTime) {
+            for (var index = Notes.Children.Count - 1; index >= 0; --index) {
+                if (Notes.Children[index].EndTime > trackTime) {
+                    break;
+                }
+                RemoveNote(Notes.Children[index]);
+            }
+        }
+
         public void Open(string path, bool isForEditor) {
             Commands.Clear();
             var text = File.ReadAllText(path);


### PR DESCRIPTION
Fixes lag that occurs when starting Play where there are notes prior to the start point (the more the laggier). This was caused by a bug in RemoveNotesUpTo in which Notes were being removed but Approaches weren't. As such, the Story.Remove is now called instead of Notes.Remove