### PR TITLE
211 Fix seek to end failing due to precision error

### DIFF
--- a/S2VX.Game/Editor/Containers/NotesTimeline.cs
+++ b/S2VX.Game/Editor/Containers/NotesTimeline.cs
@@ -233,14 +233,13 @@ namespace S2VX.Game.Editor.Containers {
         }
 
         public void SnapToTick(bool snapLeft) {
-            var tolerance = 0.02; // ms away from a tick will be considered to be on that tick
             var numTicks = Story.BPM / 60f * (Editor.Track.Length / SecondsToMS) * Divisor;
             var timeBetweenTicks = Editor.Track.Length / numTicks;
             var currentTick = (Time.Current - Story.Offset) / timeBetweenTicks;
             var currentTickTime = currentTick * timeBetweenTicks;
             var nearestTick = Math.Round(currentTick);
             var nearestTickTime = nearestTick * timeBetweenTicks;
-            var onTick = Math.Abs(nearestTickTime - currentTickTime) <= tolerance;
+            var onTick = Math.Abs(nearestTickTime - currentTickTime) <= EditorScreen.TrackTimeTolerance;
             var leftTickTime = timeBetweenTicks;
             var rightTickTime = timeBetweenTicks;
             if (onTick) {

--- a/S2VX.Game/Editor/EditorScreen.cs
+++ b/S2VX.Game/Editor/EditorScreen.cs
@@ -22,6 +22,9 @@ using System;
 
 namespace S2VX.Game.Editor {
     public class EditorScreen : Screen {
+
+        public const double TrackTimeTolerance = 0.02;  // ms away from a tick or end of track will be considered to be on that tick or end of track
+
         private string AudioPath { get; set; }
         private StorageBackedResourceStore CurLevelResourceStore { get; set; }
         private string CurSelectionPath { get; set; }
@@ -322,12 +325,15 @@ namespace S2VX.Game.Editor {
             }
         }
 
-        public void Restart() {
-            Track.Seek(0);
-            Story.ClearActives();
-        }
+        public void Restart() => Seek(0);
 
         public void Seek(double time) {
+            // This check is done for two reasons:
+            // 1. If Track.TrackLoaded is false, and therefore length is 0
+            // 2. If the track's length is truly less than track time tolerance
+            if (Track.Length >= TrackTimeTolerance) {
+                time = Math.Clamp(time, 0, Track.Length - TrackTimeTolerance);
+            }
             Track.Seek(time);
             Story.ClearActives();
         }


### PR DESCRIPTION
Bug was due to seek being called with the exact length of the track. Due to BASS precision errors, this Seek was actually seeking past the end of the track by fractions of a millisecond, causing it to fail. Fix was to take the requested Seek time and to shave a tolerance off the end to account for this precision error, similar to what was done with the Tick snapping.