### PR TITLE
Change HoldNote scoring

### DIFF
--- a/S2VX.Game/Story/Note/GameHoldNote.cs
+++ b/S2VX.Game/Story/Note/GameHoldNote.cs
@@ -42,7 +42,6 @@ namespace S2VX.Game.Story.Note {
         private void Delete() {
             ScoreBefore = Math.Clamp(ScoreBefore, 0, MissThreshold);
             ScoreAfter = Math.Clamp(ScoreAfter, 0, MissThreshold);
-            Console.WriteLine(ScoreBefore + " " + ScoreDuring + " " + ScoreAfter);
             var totalScore = ScoreBefore + ScoreDuring + ScoreAfter;
             ScoreInfo.AddScore(totalScore);
             PlayScreen.PlayInfoBar.RecordHitError(totalScore);

--- a/S2VX.Game/Story/Note/HoldNoteState.cs
+++ b/S2VX.Game/Story/Note/HoldNoteState.cs
@@ -1,8 +1,0 @@
-﻿namespace S2VX.Game.Story.Note {
-    public enum HoldNoteState {
-        NotVisibleBefore,
-        VisibleBefore,
-        During,
-        VisibleAfter
-    }
-}

--- a/S2VX.Game/Story/Note/HoldNoteState.cs
+++ b/S2VX.Game/Story/Note/HoldNoteState.cs
@@ -1,0 +1,8 @@
+﻿namespace S2VX.Game.Story.Note {
+    public enum HoldNoteState {
+        NotVisibleBefore,
+        VisibleBefore,
+        During,
+        VisibleAfter
+    }
+}


### PR DESCRIPTION
HoldNote now gives score based on time not held down during the hold note + held too early/late.
Also modified logic to allow for switching of key used mid-hold.
ClickNote now must be called before assigning the KeyBeingHeld to avoid sounds being repeatedly played during hold.