### PR TITLE
285 Pipeline update

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,18 @@
+name-template: '$RESOLVED_VERSION'
+tag-template: '$RESOLVED_VERSION'
+
+version-resolver:
+  major:
+    labels:
+    - 'major'
+  minor:
+    labels:
+    - 'minor'
+  patch:
+    labels:
+    - 'patch'
+
+template: |
+  ## Changes
+
+  $CHANGES

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,26 +1,36 @@
-name: .NET Core
+name: Continuous Integration
 
-on: push
+on:
+  push:
+    branches-ignore:
+      - master
 
 jobs:
-  ci:
+  continuous-integration:
     runs-on: ${{ matrix.os }}
-    env:
-      DOTNET_NOLOGO: true
-      DOTNET_CLI_TELEMETRY_OPTOUT: true
+
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
+
+    env:
+      DOTNET_NOLOGO: true
+      DOTNET_CLI_TELEMETRY_OPTOUT: true
+
     steps:
-    - name: Checkout
+    - name: Checkout code
       uses: actions/checkout@v2
+
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: 3.1.x
+
     - name: Install dependencies
       run: dotnet restore
-    - name: Build
+
+    - name: Build project
       run: dotnet build --configuration Release --no-restore /p:TreatWarningsAsErrors=true /warnAsError
-    - name: Test
+
+    - name: Test project
       run: dotnet test --no-restore

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -19,8 +19,8 @@ jobs:
       with:
         dotnet-version: 3.1.x
     - name: Install dependencies
-      run: dotnet restore
+      run: dotnet restore --verbosity diagnostic
     - name: Build
       run: dotnet build --configuration Release --no-restore /p:TreatWarningsAsErrors=true /warnAsError
     - name: Test
-      run: dotnet test --no-restore --verbosity diagnostic
+      run: dotnet test --no-restore

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -3,7 +3,7 @@ name: .NET Core
 on: push
 
 jobs:
-  build:
+  ci:
     runs-on: ${{ matrix.os }}
     env:
       DOTNET_NOLOGO: true

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -5,6 +5,9 @@ on: push
 jobs:
   build:
     runs-on: ${{ matrix.os }}
+    env:
+      DOTNET_NOLOGO: true
+      DOTNET_CLI_TELEMETRY_OPTOUT: true
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest]

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [windows-latest, ubuntu-latest, macos-latest]
+        os: [windows-latest, ubuntu-latest]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -19,7 +19,7 @@ jobs:
       with:
         dotnet-version: 3.1.x
     - name: Install dependencies
-      run: dotnet restore --verbosity detailed
+      run: dotnet restore --verbosity normal
     - name: Build
       run: dotnet build --configuration Release --no-restore /p:TreatWarningsAsErrors=true /warnAsError
     - name: Test

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -19,7 +19,7 @@ jobs:
       with:
         dotnet-version: 3.1.x
     - name: Install dependencies
-      run: dotnet restore --verbosity minimal
+      run: dotnet restore
     - name: Build
       run: dotnet build --configuration Release --no-restore /p:TreatWarningsAsErrors=true /warnAsError
     - name: Test

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -11,16 +11,14 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
-
     steps:
+    - name: Checkout
     - uses: actions/checkout@v2
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: 3.1.x
-    - name: Install dependencies
-      run: dotnet restore --verbosity normal
     - name: Build
       run: dotnet build --configuration Release --no-restore /p:TreatWarningsAsErrors=true /warnAsError
     - name: Test
-      run: dotnet test --no-restore
+      run: dotnet test --no-build

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -23,4 +23,4 @@ jobs:
     - name: Build
       run: dotnet build --configuration Release --no-restore /p:TreatWarningsAsErrors=true /warnAsError
     - name: Test
-      run: dotnet test --no-build
+      run: dotnet test --no-restore

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -10,7 +10,7 @@ jobs:
       DOTNET_CLI_TELEMETRY_OPTOUT: true
     strategy:
       matrix:
-        os: [windows-latest, ubuntu-latest]
+        os: [windows-latest, ubuntu-latest, macos-latest]
 
     steps:
     - uses: actions/checkout@v2
@@ -19,7 +19,7 @@ jobs:
       with:
         dotnet-version: 3.1.x
     - name: Install dependencies
-      run: dotnet restore
+      run: dotnet restore --verbosity normal
     - name: Build
       run: dotnet build --configuration Release --no-restore /p:TreatWarningsAsErrors=true /warnAsError
     - name: Test

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -13,7 +13,7 @@ jobs:
         os: [windows-latest, ubuntu-latest, macos-latest]
     steps:
     - name: Checkout
-    - uses: actions/checkout@v2
+      uses: actions/checkout@v2
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -19,7 +19,7 @@ jobs:
       with:
         dotnet-version: 3.1.x
     - name: Install dependencies
-      run: dotnet restore --verbosity normal
+      run: dotnet restore --verbosity minimal
     - name: Build
       run: dotnet build --configuration Release --no-restore /p:TreatWarningsAsErrors=true /warnAsError
     - name: Test

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -19,7 +19,7 @@ jobs:
       with:
         dotnet-version: 3.1.x
     - name: Install dependencies
-      run: dotnet restore
+      run: dotnet restore --verbosity detailed
     - name: Build
       run: dotnet build --configuration Release --no-restore /p:TreatWarningsAsErrors=true /warnAsError
     - name: Test

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [windows-latest]
+        os: [windows-latest, ubuntu-latest, macos-latest]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -10,7 +10,7 @@ jobs:
       DOTNET_CLI_TELEMETRY_OPTOUT: true
     strategy:
       matrix:
-        os: [windows-latest, ubuntu-latest]
+        os: [windows-latest]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -18,6 +18,8 @@ jobs:
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: 3.1.x
+    - name: Install dependencies
+      run: dotnet restore
     - name: Build
       run: dotnet build --configuration Release --no-restore /p:TreatWarningsAsErrors=true /warnAsError
     - name: Test

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [windows-latest, ubuntu-latest, macos-latest]
+        os: [windows-latest]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -19,7 +19,7 @@ jobs:
       with:
         dotnet-version: 3.1.x
     - name: Install dependencies
-      run: dotnet restore --verbosity diagnostic
+      run: dotnet restore
     - name: Build
       run: dotnet build --configuration Release --no-restore /p:TreatWarningsAsErrors=true /warnAsError
     - name: Test

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -10,7 +10,7 @@ jobs:
       DOTNET_CLI_TELEMETRY_OPTOUT: true
     strategy:
       matrix:
-        os: [windows-latest]
+        os: [windows-latest, ubuntu-latest]
 
     steps:
     - uses: actions/checkout@v2
@@ -23,4 +23,4 @@ jobs:
     - name: Build
       run: dotnet build --configuration Release --no-restore /p:TreatWarningsAsErrors=true /warnAsError
     - name: Test
-      run: dotnet test --no-restore
+      run: dotnet test --no-restore --verbosity diagnostic


### PR DESCRIPTION
Closes #285 sort of

There was/is(?) an odd, intermittent issue where the Windows pipeline fails during the `dotnet restore` step. I'm not really sure why. See this pipeline where this first occurs: https://github.com/maxrchung/S2VX/actions/runs/426169489

Here are a few links that point to a possibly similar issue, but none have a definite, common solution so far:
* https://github.com/actions/setup-dotnet/issues/155
* Similar problem with other NuGet action stuff https://developercommunity.visualstudio.com/content/problem/983843/dotnet-build-task-does-not-use-nugetorg-for-one-pr.html
* Could be .NET 5 related? https://github.com/actions/setup-dotnet/issues/145

For this change, I updated a few things to make the pipeline probably run a bit faster (disabling telemetry), but literally did pretty much nothing to somehow address `dotnet restore`.