### PR TITLE
Development and release instructions

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -37,10 +37,3 @@ jobs:
         asset_content_type: application/zip
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        
-    - name: Release must have Release in title
-      if: ${{ github.head_ref == 'release' }}
-      uses: deepakputhraya/action-pr-title@master
-      with:
-        allowed_prefixes: 'Release'
-        prefix_case_sensitive: true

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -37,3 +37,10 @@ jobs:
         asset_content_type: application/zip
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        
+    - name: Release must have Release in title
+      if: ${{ github.head_ref == 'release' }}
+      uses: deepakputhraya/action-pr-title@master
+      with:
+        allowed_prefixes: 'Release'
+        prefix_case_sensitive: true

--- a/.github/workflows/validate-pull-request.yml
+++ b/.github/workflows/validate-pull-request.yml
@@ -43,7 +43,7 @@ jobs:
         labels: feature, bug
 
     - name: Feature pull requests cannot have a version label
-      if: ${{ github.base_ref != 'release' && github.base_ref != 'master' }}
+      if: ${{ github.head_ref != 'release' && github.head_ref != 'master' }}
       uses: mheap/github-action-required-labels@v1
       with:
         mode: exactly
@@ -51,7 +51,7 @@ jobs:
         labels: major, minor, patch
 
     - name: Feature pull requests must have a category label
-      if: ${{ github.base_ref != 'release' && github.base_ref != 'master' }}
+      if: ${{ github.head_ref != 'release' && github.head_ref != 'master' }}
       uses: mheap/github-action-required-labels@v1
       with:
         mode: exactly

--- a/.github/workflows/validate-pull-request.yml
+++ b/.github/workflows/validate-pull-request.yml
@@ -58,7 +58,13 @@ jobs:
         count: 1
         labels: feature, bug
         
-    - name: Verify Linked Issue
+    - name: Pull requests must close an issue
       uses: hattan/verify-linked-issue-action@v1.1.1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Release must have Release in title
+      uses: deepakputhraya/action-pr-title@master
+      with:
+        allowed_prefixes: 'Release'
+        prefix_case_sensitive: true

--- a/.github/workflows/validate-pull-request.yml
+++ b/.github/workflows/validate-pull-request.yml
@@ -58,7 +58,7 @@ jobs:
         count: 1
         labels: feature, bug
         
-    - name: Pull requests must close an issue
+    - name: Pull requests must link an issue
       uses: hattan/verify-linked-issue-action@v1.1.1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/validate-pull-request.yml
+++ b/.github/workflows/validate-pull-request.yml
@@ -64,6 +64,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Release must have Release in title
+      if: ${{ github.head_ref == 'release' }}
       uses: deepakputhraya/action-pr-title@master
       with:
         allowed_prefixes: 'Release'

--- a/.github/workflows/validate-pull-request.yml
+++ b/.github/workflows/validate-pull-request.yml
@@ -64,7 +64,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Release must have Release in title
-      if: ${{ github.head_ref == 'release' }}
+      if: ${{ github.base_ref == 'release' }}
       uses: deepakputhraya/action-pr-title@master
       with:
         allowed_prefixes: 'Release'


### PR DESCRIPTION
Closes #301 

* I updated the wiki regarding the development/release process: https://github.com/maxrchung/S2VX/wiki/Development-and-Release-Flow
* I used an action to enforce release PR titles to require "Release" as a prefix, but leave the rest up to discretion. This means that "Release for some milestone", "Release for 1.3.0", "Release 20200105", "Release", and "Releaseswag" are all valid titles. I'm not a particular fan of putting the Semantic Version in the title (possibly prone to typing error) or date (already ways to identify this), so I think maybe making it somewhat open ended is better.
* I also fixed some base_ref and head_ref issues that I missed in my last pipeline update.