### PR TITLE
Fix publish release for .net 5

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -3,7 +3,7 @@ name: Publish GitHub release and artifact
 on:
   push:
     branches:
-    - release
+    - release2
 
 jobs:
   publish-release:

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -17,8 +17,8 @@ jobs:
       run: |
         cd S2VX.Desktop
         dotnet publish -p:PublishProfile=win-x64
-        zip -j S2VX.zip bin/Release/netcoreapp3.1/publish/S2VX.exe
-        zip -r S2VX.zip Stories
+        cd bin/publish
+        zip --recurse-paths S2VX.zip .
 
     - name: Publish release to GitHub
       id: release-drafter
@@ -32,7 +32,7 @@ jobs:
       uses: actions/upload-release-asset@v1
       with:
         upload_url: ${{ steps.release-drafter.outputs.upload_url }}
-        asset_path: ./S2VX.Desktop/S2VX.zip
+        asset_path: ./S2VX.Desktop/bin/publish/S2VX.zip
         asset_name: S2VX.zip
         asset_content_type: application/zip
       env:

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -3,7 +3,7 @@ name: Publish GitHub release and artifact
 on:
   push:
     branches:
-    - release2
+    - release
 
 jobs:
   publish-release:

--- a/S2VX.Desktop/Properties/PublishProfiles/win-x64.pubxml
+++ b/S2VX.Desktop/Properties/PublishProfiles/win-x64.pubxml
@@ -6,12 +6,12 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <Configuration>Release</Configuration>
     <Platform>Any CPU</Platform>
-    <PublishDir>bin\Release\netcoreapp3.1\publish\</PublishDir>
+    <PublishDir>bin\publish\</PublishDir>
     <PublishProtocol>FileSystem</PublishProtocol>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <SelfContained>true</SelfContained>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
-    <PublishSingleFile>True</PublishSingleFile>
+    <PublishSingleFile>False</PublishSingleFile>
     <PublishReadyToRun>False</PublishReadyToRun>
     <PublishTrimmed>True</PublishTrimmed>
   </PropertyGroup>


### PR DESCRIPTION
Closes #297 

- .NET is not required to be installed on the machine to run the game. This is possible because of the "self-contained" property inside of the publish profile. Of course, the overall size of the published build will increase because of it. All our past builds have been using this.

- There have been changes to the publish system when upgrading from .NET Core 3.1 to .NET 5. Most notably, it looks like for our project, we **cannot** produce and run a single executable anymore. This is due to a multitude of factors within .NET as well as with osu!framework. Basically, [.NET has some APIs that it does not support for single executable](https://docs.microsoft.com/en-us/dotnet/core/deploying/single-file#api-incompatibility), and [osu!framework does not account for this](https://github.com/ppy/osu-framework/blob/46b5d3cfd37afaf6f085d2837c79b711bf718b2c/osu.Framework/Development/DebugUtils.cs#L77).